### PR TITLE
5.9 release update

### DIFF
--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.Android/VertiGIS.Mobile.Samples.Android.csproj
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.Android/VertiGIS.Mobile.Samples.Android.csproj
@@ -53,16 +53,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Android">
-      <Version>100.8.0</Version>
+      <Version>100.9.0</Version>
     </PackageReference>
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms">
-      <Version>100.8.0</Version>
-    </PackageReference>
-    <PackageReference Include="Geocortex.Workflow.Activities.Image">
-      <Version>5.16.1.41</Version>
+      <Version>100.9.0</Version>
     </PackageReference>
     <PackageReference Include="Geocortex.Workflow.Forms.Xamarin">
-      <Version>5.16.1.490</Version>
+      <Version>5.16.1.548</Version>
     </PackageReference>
     <PackageReference Include="MarkedNet">
       <Version>2.1.2</Version>
@@ -74,13 +71,13 @@
       <Version>12.0.3</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.8.1</Version>
+      <Version>5.9.0-PullRequest13152.261</Version>
     </PackageReference>
     <PackageReference Include="Xam.Forms.MarkdownView">
       <Version>0.6.1-pre</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.617</Version>
+      <Version>4.7.0.1239</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.Android/VertiGIS.Mobile.Samples.Android.csproj
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.Android/VertiGIS.Mobile.Samples.Android.csproj
@@ -71,7 +71,7 @@
       <Version>12.0.3</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.9.0-PullRequest13152.261</Version>
+      <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="Xam.Forms.MarkdownView">
       <Version>0.6.1-pre</Version>

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.UWP/VertiGIS.Mobile.Samples.UWP.csproj
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.UWP/VertiGIS.Mobile.Samples.UWP.csproj
@@ -197,7 +197,7 @@
       <Version>12.0.3</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.9.0-PullRequest13152.261</Version>
+      <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="Xam.Forms.MarkdownView">
       <Version>0.6.1-pre</Version>

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.UWP/VertiGIS.Mobile.Samples.UWP.csproj
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.UWP/VertiGIS.Mobile.Samples.UWP.csproj
@@ -179,16 +179,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime.UWP">
-      <Version>100.8.0</Version>
+      <Version>100.9.0</Version>
     </PackageReference>
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms">
-      <Version>100.8.0</Version>
-    </PackageReference>
-    <PackageReference Include="Geocortex.Workflow.Activities.Image">
-      <Version>5.16.1.41</Version>
+      <Version>100.9.0</Version>
     </PackageReference>
     <PackageReference Include="Geocortex.Workflow.Forms.Xamarin">
-      <Version>5.16.1.490</Version>
+      <Version>5.16.1.548</Version>
     </PackageReference>
     <PackageReference Include="MarkedNet">
       <Version>2.1.2</Version>
@@ -200,13 +197,13 @@
       <Version>12.0.3</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.8.1</Version>
+      <Version>5.9.0-PullRequest13152.261</Version>
     </PackageReference>
     <PackageReference Include="Xam.Forms.MarkdownView">
       <Version>0.6.1-pre</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.617</Version>
+      <Version>4.7.0.1239</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.iOS/VertiGIS.Mobile.Samples.iOS.csproj
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.iOS/VertiGIS.Mobile.Samples.iOS.csproj
@@ -206,7 +206,7 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.9.0-PullRequest13152.261</Version>
+      <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="Xam.Forms.MarkdownView">
       <Version>0.6.1-pre</Version>

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.iOS/VertiGIS.Mobile.Samples.iOS.csproj
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples.iOS/VertiGIS.Mobile.Samples.iOS.csproj
@@ -185,16 +185,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms">
-      <Version>100.8.0</Version>
+      <Version>100.9.0</Version>
     </PackageReference>
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.iOS">
-      <Version>100.8.0</Version>
-    </PackageReference>
-    <PackageReference Include="Geocortex.Workflow.Activities.Image">
-      <Version>5.16.1.41</Version>
+      <Version>100.9.0</Version>
     </PackageReference>
     <PackageReference Include="Geocortex.Workflow.Forms.Xamarin">
-      <Version>5.16.1.490</Version>
+      <Version>5.16.1.548</Version>
     </PackageReference>
     <PackageReference Include="MarkedNet">
       <Version>2.1.2</Version>
@@ -209,13 +206,13 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="VertiGIS.Mobile">
-      <Version>5.8.1</Version>
+      <Version>5.9.0-PullRequest13152.261</Version>
     </PackageReference>
     <PackageReference Include="Xam.Forms.MarkdownView">
       <Version>0.6.1-pre</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.617</Version>
+      <Version>4.7.0.1239</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/App/GeocortexMobileViewer/layout-large.xml
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/App/GeocortexMobileViewer/layout-large.xml
@@ -47,7 +47,7 @@
     <!-- Taskbar / layers -->
     <layer-list id="layers"/>
     
-    <!-- Basmeap picker -->
+    <!-- Taskbar / basemap picker -->
     <basemap-picker/>
 
     <!-- Taskbar / map areas -->

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/App/GeocortexMobileViewer/layout-large.xml
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/App/GeocortexMobileViewer/layout-large.xml
@@ -3,12 +3,12 @@
     xmlns="https://geocortex.com/layout/v1"
     xmlns:gxm="https://geocortex.com/layout/mobile/v1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://geocortex.com/layout/v1 ../../../../../ViewerSpec/layout/layout-mobile.xsd">
+    xsi:schemaLocation="https://geocortex.com/layout/v1 ../../ViewerSpec/layout/layout-mobile.xsd">
   <gxm:taskbar id="taskbar" orientation="vertical">
 
     <!-- Taskbar main content -->
     <map id="page1-map1" config="map1" slot="main">
-      <gxm:geometry-toolbar slot="top-center-visible" id="geometry-toolbar" config="geometry" margin="0.8" style="map-widget" active="false" />
+      <gxm:geometry-toolbar slot="top-center-visible" id="geometry-toolbar" config="geometry" margin="0.8" style="round" active="false" />
       <search-new-extent config="search" margin="0.8" slot="top-center-visible" active="false" />
       <stack margin="0.8" slot="top-right" halign="end">
         <iwtm config="iwtm" id="IWTM">
@@ -19,10 +19,15 @@
         <compass id="compass" margin="0.5"/>
         <geolocate id="geolocator" margin="0.5" config="geolocate" />
       </stack>
-      <zoom margin="0.8" slot="top-left"/>
+      <stack margin="0.5" slot="top-left">
+        <zoom margin="0.3"/>
+        <expand margin="0.3" style="round">
+          <legend/>
+        </expand>
+      </stack>
       <stack margin="0.5" slot="bottom-left" halign="start">
         <split valign="center">
-          <button config="measureAction" icon="measure" style="map-widget" margin="0.3"/>
+          <button config="measureAction" icon="measure" style="round" margin="0.3"/>
           <scalebar margin="0.3"/>
         </split>
       </stack>
@@ -41,9 +46,9 @@
 
     <!-- Taskbar / layers -->
     <layer-list id="layers"/>
-
-    <!-- Taskbar / legend -->
-    <legend id="legend"/>
+    
+    <!-- Basmeap picker -->
+    <basemap-picker/>
 
     <!-- Taskbar / map areas -->
     <panel>

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/App/GeocortexMobileViewer/layout-small.xml
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/App/GeocortexMobileViewer/layout-small.xml
@@ -3,7 +3,7 @@
     xmlns="https://geocortex.com/layout/v1"
     xmlns:gxm="https://geocortex.com/layout/mobile/v1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://geocortex.com/layout/v1 ../../../../../ViewerSpec/layout/layout-mobile.xsd"
+    xsi:schemaLocation="https://geocortex.com/layout/v1 ../../ViewerSpec/layout/layout-mobile.xsd"
     orientations="portrait">
   <gxm:taskbar id="taskbar" orientation="horizontal">
 
@@ -11,21 +11,29 @@
     <map id="page1-map1" config="map1" slot="main">
       <gxm:geometry-toolbar slot="top" id="geometry-toolbar" config="geometry" active="false" />
       <search-new-extent config="search" margin="0.8" slot="bottom-center-visible" />
+      <stack margin="0.5" slot="top-left">
+        <zoom margin="0.3"/>
+        <expand margin="0.3" style="round">
+          <legend/>
+        </expand>
+        <expand margin="0.3" style="round">
+          <basemap-picker/>
+        </expand>
+      </stack>
       <stack margin="0.8" slot="top-right" halign="end">
         <iwtm config="iwtm" id="IWTM">
           <user slot="bottom"/>
         </iwtm>
       </stack>
+      <stack margin="0.5" slot="bottom-left" halign="start">
+        <split valign="center">
+          <button config="measureAction" icon="measure" style="round" margin="0.3"/>
+          <scalebar margin="0.3"/>
+        </split>
+      </stack>
       <stack margin="0.5" slot="bottom-right" halign="end">
         <compass id="compass" margin="0.5"/>
         <geolocate id="geolocator" margin="0.5" config="geolocate" />
-      </stack>
-      <zoom margin="0.8" slot="top-left"/>
-      <stack margin="0.5" slot="bottom-left" halign="start">
-        <split valign="center">
-          <button config="measureAction" icon="measure" style="map-widget" margin="0.3"/>
-          <scalebar margin="0.3"/>
-        </split>
       </stack>
     </map>
 
@@ -43,9 +51,6 @@
     <!-- Taskbar / layers -->
     <layer-list id="layers"/>
 
-    <!-- Taskbar / legend -->
-    <legend id="legend"/>
-
     <!-- Taskbar / map areas -->
     <panel>
       <gxm:offline-areas config="offline"/>
@@ -62,6 +67,7 @@
     <panel>
       <workflow config="workflow" icon="workflow"/>
     </panel>
+
   </gxm:taskbar>
 
   <!-- GNSS metadata dialog and device selection-->

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/Custom/Operation/operation.xml
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/Custom/Operation/operation.xml
@@ -12,9 +12,9 @@
     <custom:operation slot="top-center-visible"/>
 
     <stack slot="bottom-center-visible">
-      <button margin="2" style="map-widget" icon="info" config="displayMapInfo">Operation from json app</button>
-      <button margin="2" style="map-widget" icon="warning" command="custom.operation">Operation from xml layout</button>
-      <button margin="2" style="map-widget" icon="error" config="displayMapInfoConfig">Operation with configuration</button>
+      <button margin="2" style="round" icon="info" config="displayMapInfo">Operation from json app</button>
+      <button margin="2" style="round" icon="warning" command="custom.operation">Operation from xml layout</button>
+      <button margin="2" style="round" icon="error" config="displayMapInfoConfig">Operation with configuration</button>
     </stack>
   </map>
 

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/Layout/ButtonStyles/README.md
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/Layout/ButtonStyles/README.md
@@ -11,4 +11,4 @@ This sample demonstrates the Geocortex Mobile button styles that are available.
   - round: text
   - square (default): icon and text
   - round: icon and text
-- Map Widget styles are commonly used for buttons placed on the map.
+- Round styles are commonly used for buttons placed on the map.

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/Layout/ButtonStyles/README.md
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/Layout/ButtonStyles/README.md
@@ -5,10 +5,10 @@ This sample demonstrates the Geocortex Mobile button styles that are available.
 
 ### Tips
 - There a 6 basic styles:
-  - icon
-  - map-widget: icon
-  - text
-  - map-widget: text
-  - icon and text
-  - map-widget: icon and text
+  - square (default): icon
+  - round: icon
+  - square (default): text
+  - round: text
+  - square (default): icon and text
+  - round: icon and text
 - Map Widget styles are commonly used for buttons placed on the map.

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/Layout/ButtonStyles/button-styles.xml
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/Layout/ButtonStyles/button-styles.xml
@@ -9,11 +9,11 @@
 
   <panel>
     <stack title="Button Styles" halign="start">
-      <text margin="1">Map Widget Buttons</text>
+      <text margin="1">Round Buttons</text>
       <button style="round" icon="check" margin="1"/>
       <button style="round" margin="1">Text</button>
       <button style="round" icon="check" margin="1">Text and Icon</button>
-      <text margin="1">Normal Buttons</text>
+      <text margin="1">Square (Default) Buttons</text>
       <button icon="check" margin="1"/>
       <button margin="1">Text</button>
       <button icon="check" margin="1">Text and Icon</button>

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/Layout/ButtonStyles/button-styles.xml
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/Layout/ButtonStyles/button-styles.xml
@@ -10,9 +10,9 @@
   <panel>
     <stack title="Button Styles" halign="start">
       <text margin="1">Map Widget Buttons</text>
-      <button style="map-widget" icon="check" margin="1"/>
-      <button style="map-widget" margin="1">Text</button>
-      <button style="map-widget" icon="check" margin="1">Text and Icon</button>
+      <button style="round" icon="check" margin="1"/>
+      <button style="round" margin="1">Text</button>
+      <button style="round" icon="check" margin="1">Text and Icon</button>
       <text margin="1">Normal Buttons</text>
       <button icon="check" margin="1"/>
       <button margin="1">Text</button>

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/Layout/LayoutProperties/layout-properties.xml
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/Layout/LayoutProperties/layout-properties.xml
@@ -49,12 +49,12 @@
     </stack>
 
     <map grow="2">
-      <button margin="5" slot="top-left" style="map-widget" icon="check"/>
-      <button margin="5" slot="top-right" style="map-widget" icon="check"/>
-      <button margin="5" slot="top-center-visible" style="map-widget" icon="check"/>
-      <button margin="5" slot="bottom-left" style="map-widget" icon="check" height="2" width="2"/>
-      <button margin="5" slot="bottom-center-visible" style="map-widget" icon="check" height="4" width="4"/>
-      <button margin="5" slot="bottom-right" style="map-widget" icon="check" height="8" width="8" />
+      <button margin="5" slot="top-left" style="round" icon="check"/>
+      <button margin="5" slot="top-right" style="round" icon="check"/>
+      <button margin="5" slot="top-center-visible" style="round" icon="check"/>
+      <button margin="5" slot="bottom-left" style="round" icon="check" height="2" width="2"/>
+      <button margin="5" slot="bottom-center-visible" style="round" icon="check" height="4" width="4"/>
+      <button margin="5" slot="bottom-right" style="round" icon="check" height="8" width="8" />
     </map>
 
     <stack grow="1">

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/Workflow/RunWorkflow/run-workflow.xml
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/Samples/Workflow/RunWorkflow/run-workflow.xml
@@ -16,7 +16,7 @@
         </iwtm>
       </stack>
       <stack margin="0.8" slot="bottom-right" halign="end">
-        <button style="map-widget" config="launchWorkflow" />
+        <button style="round" config="launchWorkflow" />
       </stack>
     </map>
 

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/VertiGIS.Mobile.Samples.csproj
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/VertiGIS.Mobile.Samples.csproj
@@ -168,16 +168,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime" Version="100.8.0" />
-    <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms" Version="100.8.0" />
-    <PackageReference Include="Geocortex.Workflow.Activities.Image" Version="5.16.1.41" />
-    <PackageReference Include="Geocortex.Workflow.Forms.Xamarin" Version="5.16.1.490" />
+    <PackageReference Include="Esri.ArcGISRuntime" Version="100.9.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms" Version="100.9.0" />
+    <PackageReference Include="Geocortex.Workflow.Forms.Xamarin" Version="5.16.1.548" />
     <PackageReference Include="MarkedNet" Version="2.1.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="VertiGIS.Mobile" Version="5.8.1" />
+    <PackageReference Include="VertiGIS.Mobile" Version="5.9.0-PullRequest13152.261" />
     <PackageReference Include="Xam.Forms.MarkdownView" Version="0.6.1-pre" />
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" />
+    <PackageReference Include="Xamarin.Forms" Version="4.7.0.1239" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/VertiGIS.Mobile.Samples.csproj
+++ b/Geocortex.Mobile.Samples/Geocortex.Mobile.Samples/VertiGIS.Mobile.Samples.csproj
@@ -174,7 +174,7 @@
     <PackageReference Include="MarkedNet" Version="2.1.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="VertiGIS.Mobile" Version="5.9.0-PullRequest13152.261" />
+    <PackageReference Include="VertiGIS.Mobile" Version="5.9.0" />
     <PackageReference Include="Xam.Forms.MarkdownView" Version="0.6.1-pre" />
     <PackageReference Include="Xamarin.Forms" Version="4.7.0.1239" />
   </ItemGroup>


### PR DESCRIPTION
Updated VertiGIS.Mobile package to 5.9. PR build for now. Will update to final package version before completing merge.
Updated other packages to match VergiGIS.Mobile 5.9 dependencies.
Updated layout.xml files to make use of expand component.
Updated layout style attributes to use "round" instead of "map-widget".